### PR TITLE
fix(interface): checking if interface is null before calling it

### DIFF
--- a/android/src/main/java/com/aerofs/reactnativeautoupdater/ReactNativeAutoUpdater.java
+++ b/android/src/main/java/com/aerofs/reactnativeautoupdater/ReactNativeAutoUpdater.java
@@ -113,11 +113,15 @@ public class ReactNativeAutoUpdater {
         if (attempts >= MAX_ATTEMPTS) {
             Log.d(TAG, "Reached max download attempts");
             attempts = 0;
-            this.activity.updateGiveUp();
+            if (this.activity != null) {
+                this.activity.updateGiveUp();
+            }
             return;
         }
 
-        this.activity.updateFailed(attempts, error);
+        if (this.activity != null) {
+            this.activity.updateFailed(attempts, error);
+        }
 
         Log.d(TAG, "Retrying update...");
         FetchMetadataTask task = new FetchMetadataTask();
@@ -280,7 +284,9 @@ public class ReactNativeAutoUpdater {
     }
 
     private void updateDownloaded() {
-        this.activity.updateFinished();
+        if (this.activity != null) {
+            this.activity.updateFinished();
+        }
     }
 
     private void showProgressToast(int message) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loggi/react-native-auto-updater",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A library to manage dynamic updates to React Native apps. Available as an NPM Package.",
   "main": "react-native-auto-updater.js",
   "author": "Rahul Jiresal <rahul@aerofs.com> (https://github.com/rahuljiresal)",


### PR DESCRIPTION
**Status**

Finalizado.

**Objetivo**

A atualização do bundle do React pode ser feita quando o app está em background. Logo, nem sempre haverá uma Activity para receber o resultado desse processo.

Esse PR adiciona uma verificação antes de cada callback, para garantir que temos uma Activity rodando naquele momento.

Corrige o crash:

- https://fabric.io/loggi/android/apps/com.loggi.driverapp/issues/5935acc6be077a4dccb809c0?time=last-thirty-days